### PR TITLE
Add preventDefault to key listeners

### DIFF
--- a/game.js
+++ b/game.js
@@ -69,8 +69,14 @@ index 0000000000000000000000000000000000000000..d7c2e3e43b244bbee145a9f8e7d23ffa
 +
 +// --- input handling ---
 +const keys = {};
-+document.addEventListener("keydown", e => (keys[e.key] = true));
-+document.addEventListener("keyup", e => (keys[e.key] = false));
++document.addEventListener("keydown", e => {
++  e.preventDefault();
++  keys[e.key] = true;
++});
++document.addEventListener("keyup", e => {
++  e.preventDefault();
++  keys[e.key] = false;
++});
 +
 +function handleInput() {
 +  player.dx = 0;


### PR DESCRIPTION
## Summary
- call `preventDefault` in the keydown/keyup handlers so the game controls do not trigger browser shortcuts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8df44ea588331b4c58e7427d69e59